### PR TITLE
Switch to Amazon Linux 2 from Amazon ECR Public.

### DIFF
--- a/graviton2/cs_graviton/app/Dockerfile
+++ b/graviton2/cs_graviton/app/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:14
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 WORKDIR /usr/src/app
 COPY package*.json nodejs_code/app.js ./
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
+RUN yum -y install nodejs
 RUN npm install
 EXPOSE 3000
 CMD ["node", "app.js"]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Switching to Amazon ECR Public and use Amazon Linux 2 + install Node.js 14. This avoids throttling that occurs from Docker Hub when pulling anonymously.

Tested it on the workshop for both EKS and ECS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
