### PR TITLE
Update rds_mysql_8.py

### DIFF
--- a/graviton2/rds_graviton/rds_mysql_8.py
+++ b/graviton2/rds_graviton/rds_mysql_8.py
@@ -14,7 +14,7 @@ class CdkRds8Stack(core.Stack):
 
         db_mysql8 = rds.DatabaseInstance(self, "MySQL8",
                                              engine=rds.DatabaseInstanceEngine.mysql(
-                                                 version=rds.MysqlEngineVersion.VER_8_0_21
+                                                 version=rds.MysqlEngineVersion.VER_8_0_23
                                              ),
                                              instance_type=ec2.InstanceType("m5.4xlarge"),
                                              vpc=vpc,


### PR DESCRIPTION
Upgrades mysql from deprecated version.

*Issue #, if available:*

*Description of changes:*
CDK No longer supports the 8.0.21 version of mysql, this changes it to 8.0.23


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
