### PR TITLE
Update rds_restore.py

### DIFF
--- a/graviton2/rds_graviton/rds_restore.py
+++ b/graviton2/rds_graviton/rds_restore.py
@@ -17,7 +17,7 @@ class CdkRdsRestoreStack(core.Stack):
         snapshot_id = ssm.StringParameter.value_for_string_parameter(self ,"graviton_rds_lab_snapshot")
         g2_db_mysql8 = rds.DatabaseInstanceFromSnapshot(self, "GravitonMySQL",
                                              engine=rds.DatabaseInstanceEngine.mysql(
-                                                 version=rds.MysqlEngineVersion.VER_8_0_21
+                                                 version=rds.MysqlEngineVersion.VER_8_0_23
                                              ),
                                              instance_type=ec2.InstanceType("m6g.4xlarge"),
                                              snapshot_identifier=snapshot_id,


### PR DESCRIPTION
Upgrades mysql from deprecated version 8.0.21 to 8.0.23

*Issue #, if available:*

*Description of changes:*
Found another place with deprecated MySQL version 8.0.21 - supplements other PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
