### PR TITLE
updated .gitignore for dotnet and testdb folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ __pycache__
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+#workshop sub-repos
+dotnet-docker
+test_db


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During the course of the workshop the user is asked to clone repos into the root of the workshop directory. Currently these files are not ignored, which causes them to show up on the users working copy. Updated ignore file so this no longer occurs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
