### PR TITLE
fix warning messae beta.kubernetes.io/arch is deprecated since v1.14

### DIFF
--- a/graviton2/cs_graviton/Deployment-aspnet.yaml
+++ b/graviton2/cs_graviton/Deployment-aspnet.yaml
@@ -45,7 +45,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - arm64

--- a/graviton2/cs_graviton/Deployment.yaml
+++ b/graviton2/cs_graviton/Deployment.yaml
@@ -45,7 +45,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64


### PR DESCRIPTION
*Description of changes:*

Fix warning message: 
`beta.kubernetes.io/arch is deprecated since v1.14; use "kubernetes.io/arch" instead`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
