### PR TITLE
RDS MySQL 5 and 8 version upgrades

### DIFF
--- a/graviton2/rds_graviton/rds_mysql_5.py
+++ b/graviton2/rds_graviton/rds_mysql_5.py
@@ -16,7 +16,7 @@ class CdkRds5Stack(cdk.Stack):
         MySQL5secgroup = ec2.SecurityGroup(self, id="MySQL5secgroup", vpc=vpc)
         db_mysql5 = rds.DatabaseInstance(self, "MySQL5",
                                              engine=rds.DatabaseInstanceEngine.mysql(
-						 version=rds.MysqlEngineVersion.of('5.7.40','5.7')
+						 version=rds.MysqlEngineVersion.of('5.7.44','5.7')
                                              ),
                                              instance_type=ec2.InstanceType("m5.4xlarge"),
                                              vpc=vpc,

--- a/graviton2/rds_graviton/rds_mysql_8.py
+++ b/graviton2/rds_graviton/rds_mysql_8.py
@@ -16,7 +16,7 @@ class CdkRds8Stack(cdk.Stack):
         MySQL8secgroup = ec2.SecurityGroup(self, id="MySQL8secgroup", vpc=vpc)
         db_mysql8 = rds.DatabaseInstance(self, "MySQL8",
                                              engine=rds.DatabaseInstanceEngine.mysql(
-						 version=rds.MysqlEngineVersion.of('8.0.31','8.0')
+						 version=rds.MysqlEngineVersion.of('8.0.36','8.0')
                                              ),
                                              instance_type=ec2.InstanceType("m5.4xlarge"),
                                              vpc=vpc,

--- a/graviton2/rds_graviton/rds_restore.py
+++ b/graviton2/rds_graviton/rds_restore.py
@@ -19,7 +19,7 @@ class CdkRdsRestoreStack(cdk.Stack):
         snapshot_id = ssm.StringParameter.value_for_string_parameter(self ,"graviton_rds_lab_snapshot")
         g2_db_mysql8 = rds.DatabaseInstanceFromSnapshot(self, "GravitonMySQL",
                                              engine=rds.DatabaseInstanceEngine.mysql(
-						 version=rds.MysqlEngineVersion.of('8.0.31','8.0')
+						 version=rds.MysqlEngineVersion.of('8.0.36','8.0')
                                              ),
                                              instance_type=ec2.InstanceType("m6g.4xlarge"),
                                              snapshot_identifier=snapshot_id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating RDS version for RDS MySQL 5 and 8 databases used in this workshop.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
