### PR TITLE
PgSQL14 Graviton DB

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,9 @@
 import aws_cdk as cdk
 from graviton2.rds_graviton.rds_mysql_5 import CdkRds5Stack
 from graviton2.rds_graviton.rds_mysql_8 import CdkRds8Stack
+from graviton2.rds_graviton.rds_pgsql_14 import CdkPgSQLStack
 from graviton2.rds_graviton.rds_restore import CdkRdsRestoreStack
+from graviton2.rds_graviton.rds_pg_restore import CdkRdsPgRestoreStack
 from graviton2.vpc_base.vpc import CdkVpcStack
 from graviton2.cs_graviton.eks_graviton2 import CdkEksStack
 from graviton2.cs_graviton.ecs_graviton2 import CdkEcsStack
@@ -24,7 +26,9 @@ class GravitonID(cdk.App):
             self.base_module = CdkVpcStack(self, self.stack_name + "-base")
             self.rds_5_module = CdkRds5Stack(self, self.stack_name + "-rds-5", self.base_module.vpc)
             self.rds_8_module = CdkRds8Stack(self, self.stack_name + "-rds-8", self.base_module.vpc)
+            self.rds_pg14_module = CdkPgSQLStack(self, self.stack_name + "-rds-pg14", self.base_module.vpc)
             self.restore_module = CdkRdsRestoreStack(self, self.stack_name + "-rds-restore",self.base_module.vpc)
+            self.restore_pg_module = CdkRdsPgRestoreStack(self, self.stack_name + "-rds-pg-restore",self.base_module.vpc)
             self.eks_module = CdkEksStack(self, self.stack_name + "-eks", self.base_module.vpc)
             self.ecs_module = CdkEcsStack(self, self.stack_name + "-ecs", self.base_module.vpc)
             self.pipeline_module = CdkPipelineStack(self, self.stack_name + "-pipeline", self.base_module.vpc)

--- a/graviton2/rds_graviton/rds_pg_restore.py
+++ b/graviton2/rds_graviton/rds_pg_restore.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+
+import aws_cdk as cdk
+from constructs import Construct
+import aws_cdk.aws_ec2 as ec2
+import aws_cdk.aws_rds as rds
+import aws_cdk.aws_ssm as ssm
+import os
+
+default_vpc_cidr = os.environ["DefaultRouteCidr"] 
+
+
+class CdkRdsPgRestoreStack(cdk.Stack):
+
+    def __init__(self, scope: Construct, id: str, vpc, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        Pgsqlsecgroup = ec2.SecurityGroup(self, id="Pgsqlsecgroup", vpc=vpc)
+        snapshot_id = ssm.StringParameter.value_for_string_parameter(self ,"graviton_rds_pg_lab_snapshot")
+        g2_db_pgsql14 = rds.DatabaseInstanceFromSnapshot(self, "GravitonPgSQL14",
+                                             engine=rds.DatabaseInstanceEngine.postgres(
+						 version=rds.PostgresEngineVersion.VER_14_11
+                                             ),
+                                             instance_type=ec2.InstanceType("m6g.4xlarge"),
+                                             snapshot_identifier=snapshot_id,
+                                             vpc=vpc,
+                                             multi_az=False,
+                                             publicly_accessible=False,
+                                             allocated_storage=100,
+                                             storage_type=rds.StorageType.GP2,
+                                             cloudwatch_logs_exports=["postgresql"],
+                                             enable_performance_insights=True,
+                                             deletion_protection=False,
+                                             delete_automated_backups=True,
+                                             backup_retention=cdk.Duration.days(0),
+					                         security_groups=[Pgsqlsecgroup],
+                                             parameter_group=rds.ParameterGroup.from_parameter_group_name(
+                                                 self, "para-group-pgsql",
+                                                 parameter_group_name="default.postgres14"
+                                             )
+                                             )
+        g2_db_pgsql14.connections.allow_default_port_from(ec2.Peer.ipv4(default_vpc_cidr), "Cloud9 PgSQL Access")
+        cdk.CfnOutput( self, "PgSQL14RDSInstanceId", value = g2_db_pgsql14.instance_identifier)
+        cdk.CfnOutput( self, "PgSQL14RSecurityGroup", value = Pgsqlsecgroup.security_group_id)

--- a/graviton2/rds_graviton/rds_pgsql_14.py
+++ b/graviton2/rds_graviton/rds_pgsql_14.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+
+import aws_cdk as cdk
+from constructs import Construct
+import aws_cdk.aws_ec2 as ec2
+import aws_cdk.aws_rds as rds
+import os
+
+default_vpc_cidr = os.environ["DefaultRouteCidr"] 
+
+class CdkPgSQLStack(cdk.Stack):
+
+    def __init__(self, scope: Construct, id: str, vpc, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        Pgsqlsecgroup = ec2.SecurityGroup(self, id="Pgsqlsecgroup", vpc=vpc)
+        pgsql_db = rds.DatabaseInstance(self, "PgSQL14",
+                                             engine=rds.DatabaseInstanceEngine.postgres(
+						 version=rds.PostgresEngineVersion.VER_14_11
+                                             ),
+                                             instance_type=ec2.InstanceType("m5.4xlarge"),
+                                             vpc=vpc,
+                                             multi_az=False,
+                                             publicly_accessible=False,
+                                             allocated_storage=100,
+                                             storage_type=rds.StorageType.GP2,
+                                             cloudwatch_logs_exports=["postgresql"],
+                                             deletion_protection=False,
+                                             enable_performance_insights=True,
+                                             delete_automated_backups=True,
+                                             backup_retention=cdk.Duration.days(0),
+					                         security_groups=[Pgsqlsecgroup],
+                                             parameter_group=rds.ParameterGroup.from_parameter_group_name(
+                                                 self, "para-group-pgsql",
+                                                 parameter_group_name="default.postgres14"
+                                             )
+                                             )
+        pgsql_db.connections.allow_default_port_from(ec2.Peer.ipv4(default_vpc_cidr), "Cloud9 PgSQL Access")
+
+        cdk.CfnOutput( self, "PgSQL14RDSInstanceId", value = pgsql_db.instance_identifier)
+        cdk.CfnOutput( self, "PgSQL14SecretArn", value = pgsql_db.secret.secret_arn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.99.1
-aws-cdk.aws-lambda-python-alpha==2.99.1a0
+aws-cdk-lib==2.133.0
+aws-cdk.aws-lambda-python-alpha==2.133.0a0
 constructs>=10.0.0,<11.0.0
-aws_cdk.lambda_layer_kubectl_v26==2.0.1
+aws_cdk.lambda_layer_kubectl_v29==2.0.0

--- a/scripts/rds-pg-snapshot.sh
+++ b/scripts/rds-pg-snapshot.sh
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+#!/bin/bash
+
+snapshot_uuid=`cat /dev/urandom | tr -dc 'a-z' | fold -w 16 | head -n 1`
+
+
+aws ssm delete-parameter --name "graviton_rds_pg_lab_snapshot" >/dev/null 2>&1
+
+echo "Saving snapshot id using AWS Systems Manager Parameter Store"
+
+aws ssm put-parameter --name "graviton_rds_pg_lab_snapshot" --value $snapshot_uuid  --type String  
+
+echo "Creating RDS database snapshot"
+
+aws rds create-db-snapshot --db-instance-identifier `aws cloudformation describe-stacks --stack-name GravitonID-rds-pg14 --query "Stacks[0].Outputs[1].OutputValue" --output text` --db-snapshot-identifier $snapshot_uuid >& /dev/null
+
+echo -e "Your snapshop id : \e[1;32m $snapshot_uuid \e[0m"

--- a/scripts/ubuntu-prereqs.sh
+++ b/scripts/ubuntu-prereqs.sh
@@ -1,7 +1,7 @@
 sudo systemctl stop apt-daily.timer
 sudo apt-get update
-sudo apt-get install -y jq gettext bash-completion moreutils 
-curl -sSL -o /tmp/kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.26.9/2023-10-12/bin/darwin/amd64/kubectl
+sudo apt-get install -y jq gettext bash-completion moreutils postgresql-client-14 postgresql-client-common
+curl -sSL -o /tmp/kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.29.0/2024-01-04/bin/linux/amd64/kubectl
 chmod +x /tmp/kubectl
 sudo mv /tmp/kubectl /usr/local/bin/kubectl
 pip3 install --upgrade awscli 
@@ -18,6 +18,6 @@ aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" || aws iam 
 aws iam get-role --role-name "AWSServiceRoleForAmazonOpenSearchService" || aws iam create-service-linked-role --aws-service-name "opensearchservice.amazonaws.com"
 sudo systemctl start apt-daily.timer
 cd ~/environment/graviton2-workshop && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
-npm -g uninstall cdk &&  npm install -g aws-cdk@2.99.1
+npm -g uninstall cdk &&  npm install -g aws-cdk@2.133.0
 cdk bootstrap
 cdk synth


### PR DESCRIPTION
## Description of changes

This change adds PostgreSQL database V14 as option in the **Graviton and Databases** topic. It requires some updates in the `requirements.txt` and `ubuntu-prereqs.sh` to use latest PostgreSQL version available (14.11) compatible with Ubuntu `psql` client. 

Still pending to write the narrative for the section but it will be quite similar to the existing one for MySQL. I changed the test database to use one compatible for PostgreSQL, also adapting the checksum example. Please, follow next steps within Cloud9 GravitonIDE environment to test it:

### Initialization 

```
cd ~/environment/graviton2-workshop/
source scripts/rds-peering.sh
```

### Restoring Graviton PgSQL database from x86-64 snapshot

Deploy the PgSQL database and initialize credentials:
```
cdk deploy GravitonID-rds-pg14
CREDS=$(aws secretsmanager get-secret-value --secret-id `aws cloudformation describe-stacks --stack-name GravitonID-rds-pg14 --query "Stacks[0].Outputs[0].OutputValue" --output text` | jq -r '.SecretString')
export DBUSER="`echo $CREDS | jq -r '.username'`"
export PGPASSWORD="`echo $CREDS | jq -r '.password'`"
export DBHOST="`echo $CREDS | jq -r '.host'`"
export DBPORT="`echo $CREDS | jq -r '.port'`"
echo $DBUSER
echo $PGPASSWORD
echo $DBHOST
echo $DBPORT
```

Download test database:
```
cd ~/environment/graviton2-workshop/
git clone https://github.com/jOOQ/sakila.git
cd ~/environment/graviton2-workshop/sakila/postgres-sakila-db/
```

Create test database and log into the `psql` console:
```
psql -q -h $DBHOST -p $DBPORT -U $DBUSER -c 'create database test;'
psql -q -h $DBHOST -p $DBPORT -U $DBUSER test
```

Within he `psql` console, run next commands to create the DB schema and import data. Some errors will show up during import phase but are not relevant for the test. Please, ignore them:
```
\i postgres-sakila-schema.sql
\i postgres-sakila-insert-data-using-copy.sql
```

Check data has been imported correctly by running a simple `select` statement for the `actor` table. Then, run the `md5` command to generate the checksum that will be used to validate data consistency after migrating to Graviton:
```
test=> select * from actor order by actor_id limit 10;
 actor_id | first_name |  last_name   |     last_update     
----------+------------+--------------+---------------------
        1 | PENELOPE   | GUINESS      | 2006-02-15 04:34:33
        2 | NICK       | WAHLBERG     | 2006-02-15 04:34:33
        3 | ED         | CHASE        | 2006-02-15 04:34:33
        4 | JENNIFER   | DAVIS        | 2006-02-15 04:34:33
        5 | JOHNNY     | LOLLOBRIGIDA | 2006-02-15 04:34:33
        6 | BETTE      | NICHOLSON    | 2006-02-15 04:34:33
        7 | GRACE      | MOSTEL       | 2006-02-15 04:34:33
        8 | MATTHEW    | JOHANSSON    | 2006-02-15 04:34:33
        9 | JOE        | SWANK        | 2006-02-15 04:34:33
       10 | CHRISTIAN  | GABLE        | 2006-02-15 04:34:33
(10 rows)

test=> select md5(cast((array_agg(actor.* order by actor_id))as text)) from actor;                                                                                                                                              
               md5                
----------------------------------
 a43bbb36d8b17945c86d552f3edebe1e
(1 row)

test=> 
```
Exit `psql` console by pressing CTRL+D.

Create DB snapshot:
```
cd ~/environment/graviton2-workshop/
~/environment/graviton2-workshop/scripts/rds-pg-snapshot.sh
```

Run next command to verify when snapshot becomes `available`:
```
aws rds describe-db-snapshots --db-snapshot-identifier `aws ssm get-parameter --name "graviton_rds_pg_lab_snapshot" | jq -r .Parameter.Value` | jq -r .DBSnapshots[0].Status
```

Restore DB from snapshot:
```
cd ~/environment/graviton2-workshop/
cdk deploy GravitonID-rds-pg-restore
```

When done, verify data consistency is ok by reviewing the `md5` output - it should provide same value as before:
```
CREDS=$(aws secretsmanager get-secret-value --secret-id `aws cloudformation describe-stacks --stack-name GravitonID-rds-pg14 --query "Stacks[0].Outputs[0].OutputValue" --output text` | jq -r '.SecretString')
export DBUSER="`echo $CREDS | jq -r '.username'`"
export PGPASSWORD="`echo $CREDS | jq -r '.password'`"
export DBPORT="`echo $CREDS | jq -r '.port'`"
export DBHOST=$(aws rds describe-db-instances --db-instance-identifier `aws cloudformation describe-stacks --stack-name GravitonID-rds-pg-restore | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "PgSQL14RDSInstanceId") | .OutputValue'` | jq -r '.DBInstances[] | .Endpoint.Address')
echo $DBUSER
echo $PGPASSWORD
echo $DBHOST
echo $DBPORT
```

Log into `psql` console:
```
psql -q -h $DBHOST -p $DBPORT -U $DBUSER test
```

Expected output:
```
test=> select md5(cast((array_agg(actor.* order by actor_id))as text)) from actor; 
               md5                
----------------------------------
 a43bbb36d8b17945c86d552f3edebe1e
(1 row)

test=> 
```
Exit `psql` console by pressing CTRL+D.

### PgSQL RDS Upgrade (requires `GravitonID-rds-pg14` Stack deployed)

```
aws rds modify-db-instance --db-instance-identifier `aws cloudformation describe-stacks --stack-name GravitonID-rds-pg14 --query "Stacks[0].Outputs[1].OutputValue" --output text` --db-instance-class db.m6g.4xlarge --allow-major-version-upgrade --apply-immediately
```


### RDS Cleanup

```
cd ~/environment/graviton2-workshop/
source scripts/rds-peering-cleanup.sh
cdk destroy GravitonID-rds* -f
```
