### PR TITLE
Fix pipeline branch master->main and rds-snapshot error handling

### DIFF
--- a/graviton/cs_graviton/pipeline_graviton.py
+++ b/graviton/cs_graviton/pipeline_graviton.py
@@ -114,7 +114,7 @@ class CdkPipelineStack(cdk.Stack):
             action_name="CodeCommit_Source",
             repository=codecommit_repo,
             output=source_output,
-            branch="master"
+            branch="main"
         )
 
         pipeline.add_stage(

--- a/graviton/cs_graviton/pipeline_netcore_graviton.py
+++ b/graviton/cs_graviton/pipeline_netcore_graviton.py
@@ -66,7 +66,7 @@ class CdkPipelineDotNetStack(cdk.Stack):
             action_name="CodeCommit_Source",
             repository=codecommit_repo,
             output=source_output,
-            branch="master"
+            branch="main"
         )
 
         pipeline.add_stage(

--- a/scripts/rds-snapshot.sh
+++ b/scripts/rds-snapshot.sh
@@ -4,7 +4,7 @@
 snapshot_uuid=`cat /dev/urandom | tr -dc 'a-z' | fold -w 16 | head -n 1`
 
 
-aws ssm delete-parameter --name "graviton_rds_lab_snapshot"
+aws ssm delete-parameter --name "graviton_rds_lab_snapshot" 2>/dev/null || true
 
 echo "Saving snapshot id using AWS Systems Manager Parameter Store"
 


### PR DESCRIPTION
 ## Summary
  
  Two fixes for the Graviton Workshop:
  
  1. **CodePipeline not triggering after git push** — Both pipeline CDK stacks
     (pipeline_graviton.py and pipeline_netcore_graviton.py) watch the `master`
     branch, but CodeCommit now defaults to `main`. Participants push code and
     the pipeline never starts. Changed both to `branch="main"`.
  
  2. **RDS snapshot script shows error on first run** — rds-snapshot.sh calls
     `aws ssm delete-parameter` before the parameter exists, causing a
     ParameterNotFound error that confuses participants. Added error suppression
     so the script runs cleanly on first execution.
  
  ## Files changed
  
  - `graviton/cs_graviton/pipeline_graviton.py` — branch="master" → "main"
  - `graviton/cs_graviton/pipeline_netcore_graviton.py` — branch="master" → "main"
  - `scripts/rds-snapshot.sh` — added `2>/dev/null || true` to ssm delete
  
  ## Testing
  
  Verified against the current Workshop Studio content and CFN template which
  use `main` as the default branch and expect clean script output.
